### PR TITLE
Refactor: Extract duplicate error-checking into _check helper

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,46 +1,32 @@
-exports._check = () => {
-  // DRY up the codebase with this function
-  // First, move the duplicate error checking code here
-  // Then, invoke this function inside each of the others
-  // HINT: you can invoke this function with exports._check()
-};
-
-exports.add = (x, y) => {
+exports._check = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
+
+};
+
+exports.add = (x, y) => {
+  exports._check (x,y)
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check (x,y)
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
-  }
+  exports._check (x,y)
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  if (typeof x !== 'number') {
-    throw new TypeError(`${x} is not a number`);
-  }
-  if (typeof y !== 'number') {
-    throw new TypeError(`${y} is not a number`);
+  exports._check (x,y)
+  if (y === 0) {
+    throw new TypeError('Cannot divide by zero');
   }
   return x / y;
 };

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,32 +1,46 @@
-exports._check = (x, y) => {
+exports._check = () => {
+  // DRY up the codebase with this function
+  // First, move the duplicate error checking code here
+  // Then, invoke this function inside each of the others
+  // HINT: you can invoke this function with exports._check()
+};
+
+exports.add = (x, y) => {
   if (typeof x !== 'number') {
     throw new TypeError(`${x} is not a number`);
   }
   if (typeof y !== 'number') {
     throw new TypeError(`${y} is not a number`);
   }
-
-};
-
-exports.add = (x, y) => {
-  exports._check (x,y)
   return x + y;
 };
 
 exports.subtract = (x, y) => {
-  exports._check (x,y)
+  if (typeof x !== 'number') {
+    throw new TypeError(`${x} is not a number`);
+  }
+  if (typeof y !== 'number') {
+    throw new TypeError(`${y} is not a number`);
+  }
   return x - y;
 };
 
 exports.multiply = (x, y) => {
-  exports._check (x,y)
+  if (typeof x !== 'number') {
+    throw new TypeError(`${x} is not a number`);
+  }
+  if (typeof y !== 'number') {
+    throw new TypeError(`${y} is not a number`);
+  }
   return x * y;
 };
 
 exports.divide = (x, y) => {
-  exports._check (x,y)
-  if (y === 0) {
-    throw new TypeError('Cannot divide by zero');
+  if (typeof x !== 'number') {
+    throw new TypeError(`${x} is not a number`);
+  }
+  if (typeof y !== 'number') {
+    throw new TypeError(`${y} is not a number`);
   }
   return x / y;
 };


### PR DESCRIPTION
Hello there,

I made the code more DRY by adding a `_check` function. This allows us to remove the repetitive error-checking code from each function (add, subtract, etc.) and call `_check` instead.

This improves readability and gives us a cleaner, more maintainable codebase.
